### PR TITLE
Changed requirement for puppetlabs-stdlib to 4.15.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,6 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <2.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <4.15.0" }
   ]
 }


### PR DESCRIPTION
The requirement for version 2.0.0 is pretty old.  I've tested puppet-fstab successfully with puppet-stdlib 4.15.0.