### PR TITLE
Changed puppetlabs-concat version to 2.2.0.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,6 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <2.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <2.2.0" }
   ]
 }


### PR DESCRIPTION
Changing to 2.2.0 eases the restrictions on requirements.  Also, it makes it easier to update modules via "puppet module upgrade" at the command line.


I've tested puppetlabs-concat with no issues.