### PR TITLE
Added single quotes to selector values to maintain compatibility with…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,12 +16,12 @@ class fstab::params {
     }
     'RedHat': { # Packages for RHEL6 are different than RHEL7
       $nfs_server_package = $::lsbmajdistrelease ?  {
-        6 =>  ['nfs-utils', 'nfs-utils-lib'],
-        7 =>  ['nfs-utils', 'libnfsidmap'],
+        '6' =>  ['nfs-utils', 'nfs-utils-lib'],
+        '7' =>  ['nfs-utils', 'libnfsidmap'],
       }   
       $nfs_client_package = $::lsbmajdistrelease ?  {
-        6 =>  ['nfs-utils', 'nfs-utils-lib'],
-        7 =>  ['nfs-utils', 'libnfsidmap'],
+        '6' =>  ['nfs-utils', 'nfs-utils-lib'],
+        '7' =>  ['nfs-utils', 'libnfsidmap'],
       }
     }
   }


### PR DESCRIPTION
… Puppet 4

Puppet run fails otherwise:


`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: {"message":"Server Error: Evaluation Error: No matching entry for selector parameter with value '6' at /etc/puppetlabs/code/modules/fstab/manifests/params.pp:18:29 on node ltstd001.healthplan.com","issue_kind":"RUNTIME_ERROR"}
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run`