### PR TITLE
useless concat requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,6 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <2.2.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2" }
   ]
 }


### PR DESCRIPTION
Hi,

the requirement <2.2.0 concat is pretty useless and breaks installing this module with librarian-puppet. 
Also `concat` is just 2 times used with no functions that was breaking since a rleally long time. 

You can safely remove this constraint. 